### PR TITLE
CSCFAIRADM-166: [ADD] Change etsin test & stable URLs to *.csc.fi

### DIFF
--- a/ansible/inventories/local_development/group_vars/all
+++ b/ansible/inventories/local_development/group_vars/all
@@ -7,7 +7,7 @@ shared_folder_base_path: /metax
 
 project_repo_branch: test
 metax_app_base_path: "{{ shared_folder_base_path }}/{{ app_name }}"
-etsin_base_url: https://etsin-test.fairdata.fi
+etsin_base_url: https://etsin-test.csc.fi
 
 # allowed api auth methods in HTTP Authorization header. to disable End User access
 # altogether, remove "Bearer" from below list.

--- a/ansible/inventories/stable/group_vars/all
+++ b/ansible/inventories/stable/group_vars/all
@@ -29,4 +29,4 @@ refdataserver_external_ip: "{{ server_3_ip }}"
 metax_app_base_path: "{{ metax_base_path }}/{{ app_name }}"
 deployment_environment_id: stable
 project_repo_branch: stable
-etsin_base_url: https://etsin-stable.fairdata.fi
+etsin_base_url: https://etsin-stable.csc.fi

--- a/ansible/inventories/test/group_vars/all
+++ b/ansible/inventories/test/group_vars/all
@@ -29,4 +29,4 @@ refdataserver_external_ip: "{{ server_3_ip }}"
 metax_app_base_path: "{{ metax_base_path }}/{{ app_name }}"
 deployment_environment_id: test
 project_repo_branch: test
-etsin_base_url: https://etsin-test.fairdata.fi
+etsin_base_url: https://etsin-test.csc.fi


### PR DESCRIPTION
- Done because of a DNS change
- DNS for etsin test resources changed to csc.fi, so has to be updated