### PR TITLE
CSCFAIRMETA-648: [FIX] Remove test and stable self-generated-certs

### DIFF
--- a/ansible/roles/certificates/tasks/main.yml
+++ b/ansible/roles/certificates/tasks/main.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 - name: Create directory for SSL certificates
   file: path={{ ssl_certificates_path }} state=directory
-  when: deployment_environment_id in ['local_development', 'test', 'stable', 'staging', 'demo']
+  when: deployment_environment_id in ['local_development', 'staging', 'demo']
 
 - name: Create self-signed SSL cert and private key
   command: openssl req -x509 -nodes -subj "/C=FI/ST=Uusimaa/L=Espoo/O=CSC/CN={{ server_domain_name }}" -days 365 -newkey rsa:2048 -keyout {{ ssl_certificates_path }}/{{ ssl_key_name }} -out {{ ssl_certificates_path }}/{{ ssl_certificate_name }} creates={{ ssl_certificates_path }}/{{ ssl_certificate_name }}
@@ -29,4 +29,4 @@
     - name: Fix concatenated file carriage returns
       command: dos2unix {{ ssl_certificates_path }}/{{ ssl_certificate_name }}
 
-  when: deployment_environment_id in ['test', 'stable', 'demo']
+  when: deployment_environment_id in ['demo']

--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -41,6 +41,14 @@
 
 - name: NGINX | Generate Diffie-Hellman PFS (Perfect Forward Secrecy) group
   command: openssl dhparam -out {{ ssl_certificates_path }}/{{ nginx_dh_param_name }} 2048 creates={{ ssl_certificates_path }}/{{ nginx_dh_param_name }}
+  when: deployment_environment_id not in ['test', 'stable']
+
+- name: NGINX | For test & stable, remotely copy & rename ssl-dhparams.pem, retrieved using LetsEncrypt, to the correct location
+  copy:
+    src: /etc/letsencrypt/ssl-dhparams.pem
+    dest: /{{ ssl_certificates_path }}/nginx_dhparam.pem
+    remote_src: yes
+  when: deployment_environment_id in ['test', 'stable']
 
 - name: NGINX | Install passlib
   pip: name=passlib state=latest executable=pip3


### PR DESCRIPTION
- These certificates are now retrieved using LetsEncrypt
- Remove test and stable from several cert instructions
- Copy LetsEncrypt file to correct place, to ensure provisioning works (nginx_dhparam.pem)

Similar implementation to:
https://github.com/CSCfi/etsin-ops/pull/19