### PR TITLE
CSCFAIRMETA-212: [FIX] old ES uninstall and confs

### DIFF
--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -4,4 +4,4 @@
 ---
 
 - src: https://github.com/CSCfi/ansible-elasticsearch
-  version: a0c5a44f2aa80143c6da8eda4b2351aad73bdc27
+  version: 918b6738272b2047c408be7aab1b3dadbbe77fa3

--- a/ansible/roles/elasticsearch/tasks/main.yml
+++ b/ansible/roles/elasticsearch/tasks/main.yml
@@ -10,7 +10,6 @@
       es_instance_name: "{{ elasticsearch_instance.node_name }}"
       es_heap_size: "{{ elasticsearch_instance.heap_size }}"
       es_version: "7.8.0"
-      # es_custom_package_url: "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.11.rpm"
       es_use_repository: true
       es_major_version: "7.x"
       es_version_lock: true
@@ -40,19 +39,19 @@
 
       - name: Create directory for elasticsearch service drop-in unitfile
         file:
-          path: "/etc/systemd/system/{{ elasticsearch_instance.node_name }}_elasticsearch.service.d"
+          path: "/etc/systemd/system/elasticsearch.service.d"
           state: directory
 
       - name: Copy drop-in unitfile
         template:
           src: templates/Restart.conf
-          dest: "/etc/systemd/system/{{ elasticsearch_instance.node_name }}_elasticsearch.service.d/Restart.conf"
+          dest: "/etc/systemd/system/elasticsearch.service.d/Restart.conf"
 
       - name: Systemctl daemon-reload
         shell: "systemctl daemon-reload"
 
       - name: Restart elasticsearch service
-        service: name={{ elasticsearch_instance.node_name }}_elasticsearch state=restarted
+        service: name=elasticsearch state=restarted
 
     when: deployment_environment_id not in ['local_development']
     tags:


### PR DESCRIPTION
- Old ES version had different service name so this had to be taken
  into account. Fix was made in ansible-elasticsearch repo which
  is cloned during requirements.yml
- ES configurations had the old naming for the service file