### PR TITLE
CSCFAIRADM-421: Separate ElasticSearch config for Metax test/stable

### DIFF
--- a/ansible/roles/nginx/tasks/main.yml
+++ b/ansible/roles/nginx/tasks/main.yml
@@ -8,6 +8,13 @@
 
 - name: NGINX | Replace NGINX conf file
   template: src=templates/metax_nginx.conf dest=/etc/nginx/nginx.conf
+  when: deployment_environment_id not in ['test', 'stable']
+  tags:
+    - conf
+
+- name: NGINX | Replace NGINX conf file for test and stable (special ES parameters needed)
+  template: src=templates/metax_nginx_test_stable.conf dest=/etc/nginx/nginx.conf
+  when: deployment_environment_id in ['test', 'stable']
   tags:
     - conf
 

--- a/ansible/roles/nginx/templates/metax_nginx_test_stable.conf
+++ b/ansible/roles/nginx/templates/metax_nginx_test_stable.conf
@@ -204,34 +204,31 @@ http {
             include shared_headers.conf;
             include elastic_headers.conf;
             proxy_pass http://elasticsearch/_search/;
-            limit_except GET DELETE {
-                auth_basic 'Credentials required';
-                auth_basic_user_file /etc/nginx/nginx_auth;
-            }
+            # limit_except GET DELETE {
+            # auth_basic 'Credentials required';
+            # auth_basic_user_file /etc/nginx/nginx_auth;
+            # }
         }
 
+        # This location added for travis use as it has not password for metax
+        location ~ ^/es/(reference_data|organization_data)/[0-9a-z_]+/_search {
+            include shared_headers.conf;
+            include elastic_headers.conf;
+            rewrite ^/es/(.*)$ /$1 break;
+            proxy_pass http://elasticsearch;
+        }
+
+        # Here and in the next location authentication is disabled because of travis also
         location ~ ^/es/(reference_data|organization_data)/_search {
             # New, correct type of queries can go straight to ES
             include shared_headers.conf;
             include elastic_headers.conf;
             rewrite ^/es/(.*)$ /$1 break;
             proxy_pass http://elasticsearch;
-            limit_except GET HEAD {
-                auth_basic 'Credentials required';
-                auth_basic_user_file /etc/nginx/nginx_auth;
-            }
-        }
-
-        location ~ ^/es/(_mapping|reference_data|organization_data) {
-            # Sends old types of queries to metax, which will parse
-            # the parameters to be compatible with the new ES version
-            include shared_headers.conf;
-            include api_response_headers.conf;
-            rewrite ^/es/(.*)$ /rpc/elasticsearchs/map_refdata?$1 break;
-            proxy_pass {{ nginx_gunicorn_proxy_pass }};
-            proxy_set_header X-Forwarded-Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-Proto $scheme;
+            # limit_except GET HEAD {
+            # auth_basic 'Credentials required';
+            # auth_basic_user_file /etc/nginx/nginx_auth;
+            # }
         }
  
         location /static/ {

--- a/ansible/roles/nginx/templates/metax_nginx_test_stable.conf
+++ b/ansible/roles/nginx/templates/metax_nginx_test_stable.conf
@@ -213,6 +213,14 @@ http {
             # }
         }
 
+        # This location added for travis use as it has not password for metax
+        location ~ ^/es/(reference_data|organization_data)/[0-9a-z_]+/_search {
+            include shared_headers.conf;
+            include elastic_headers.conf;
+            rewrite ^/es/(.*)$ /$1 break;
+            proxy_pass http://elasticsearch;
+        }
+
         location /es/_search/ {
             include shared_headers.conf;
             include elastic_headers.conf;
@@ -221,14 +229,6 @@ http {
             # auth_basic 'Credentials required';
             # auth_basic_user_file /etc/nginx/nginx_auth;
             # }
-        }
-
-        # This location added for travis use as it has not password for metax
-        location ~ ^/es/(reference_data|organization_data)/[0-9a-z_]+/_search {
-            include shared_headers.conf;
-            include elastic_headers.conf;
-            rewrite ^/es/(.*)$ /$1 break;
-            proxy_pass http://elasticsearch;
         }
 
         location /static/ {

--- a/ansible/roles/nginx/templates/metax_nginx_test_stable.conf
+++ b/ansible/roles/nginx/templates/metax_nginx_test_stable.conf
@@ -200,6 +200,19 @@ http {
             return 301 https://{{ server_domain_name }}/swagger/v1;
         }
 
+        # Here and in the next location authentication is disabled because of travis also
+        location ~ ^/es/(reference_data|organization_data)/_search {
+            # New, correct type of queries can go straight to ES
+            include shared_headers.conf;
+            include elastic_headers.conf;
+            rewrite ^/es/(.*)$ /$1 break;
+            proxy_pass http://elasticsearch;
+            # limit_except GET HEAD {
+            # auth_basic 'Credentials required';
+            # auth_basic_user_file /etc/nginx/nginx_auth;
+            # }
+        }
+
         location /es/_search/ {
             include shared_headers.conf;
             include elastic_headers.conf;
@@ -218,19 +231,6 @@ http {
             proxy_pass http://elasticsearch;
         }
 
-        # Here and in the next location authentication is disabled because of travis also
-        location ~ ^/es/(reference_data|organization_data)/_search {
-            # New, correct type of queries can go straight to ES
-            include shared_headers.conf;
-            include elastic_headers.conf;
-            rewrite ^/es/(.*)$ /$1 break;
-            proxy_pass http://elasticsearch;
-            # limit_except GET HEAD {
-            # auth_basic 'Credentials required';
-            # auth_basic_user_file /etc/nginx/nginx_auth;
-            # }
-        }
- 
         location /static/ {
             include shared_headers.conf;
             include static_file_headers.conf;

--- a/ansible/roles/nginx/templates/metax_nginx_test_stable.conf
+++ b/ansible/roles/nginx/templates/metax_nginx_test_stable.conf
@@ -200,6 +200,16 @@ http {
             return 301 https://{{ server_domain_name }}/swagger/v1;
         }
 
+        location /es/_search/ {
+            include shared_headers.conf;
+            include elastic_headers.conf;
+            proxy_pass http://elasticsearch/_search/;
+            # limit_except GET DELETE {
+            # auth_basic 'Credentials required';
+            # auth_basic_user_file /etc/nginx/nginx_auth;
+            # }
+        }
+
         # Here and in the next location authentication is disabled because of travis also
         location ~ ^/es/(reference_data|organization_data)/_search {
             # New, correct type of queries can go straight to ES
@@ -213,22 +223,12 @@ http {
             # }
         }
 
-        # This location added for travis use as it has not password for metax
+        # This location added for travis use as it has no password for metax
         location ~ ^/es/(reference_data|organization_data)/[0-9a-z_]+/_search {
             include shared_headers.conf;
             include elastic_headers.conf;
             rewrite ^/es/(.*)$ /$1 break;
             proxy_pass http://elasticsearch;
-        }
-
-        location /es/_search/ {
-            include shared_headers.conf;
-            include elastic_headers.conf;
-            proxy_pass http://elasticsearch/_search/;
-            # limit_except GET DELETE {
-            # auth_basic 'Credentials required';
-            # auth_basic_user_file /etc/nginx/nginx_auth;
-            # }
         }
 
         location /static/ {

--- a/ansible/roles/nginx/templates/metax_nginx_test_stable.conf
+++ b/ansible/roles/nginx/templates/metax_nginx_test_stable.conf
@@ -1,0 +1,268 @@
+user nginx;
+worker_processes auto;
+pid /run/nginx.pid;
+
+# Load dynamic modules. See /usr/share/nginx/README.dynamic.
+include /usr/share/nginx/modules/*.conf;
+
+events {
+    worker_connections 768;
+}
+
+http {
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log on;
+    access_log  /var/log/nginx/access.log;
+    error_log /var/log/nginx/error.log;
+
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 2048;
+
+    # request timeout 3 days
+    proxy_connect_timeout       259200;
+    proxy_send_timeout          259200;
+    proxy_read_timeout          259200;
+    send_timeout                259200;
+
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
+    server_tokens       off;
+
+    # Load modular configuration files from the /etc/nginx/conf.d directory.
+    # See http://nginx.org/en/docs/ngx_core_module.html#include
+    # for more information.
+    include /etc/nginx/conf.d/*.conf;
+
+    # include common add_header statements for all responses.
+    # note: if inheriting blocks add more add_header statements, all
+    # previously included headers will be discarded!!
+    include shared_headers.conf;
+
+    gzip on;
+    gzip_disable "msie6";
+
+    # use in api responses. see api_response_headers.conf
+    map $sent_http_content_type $content_disposition {
+{% if deployment_environment_id in ['production', 'demo'] %}
+        default                            "attachment; filename=response.json";
+        "text/html"                        "attachment; filename=response.json";
+        "text/html; charset=utf-8"         "attachment; filename=response.json";
+{% endif %}
+{% if deployment_environment_id not in ['production', 'demo'] %}
+        default                            "inline";
+{% endif %}
+        "application/json"                 "attachment; filename=response.json";
+        "application/json; charset=utf-8"  "attachment; filename=response.json";
+        "application/xml"                  "attachment; filename=response.xml";
+        "application/xml; charset=utf-8"   "attachment; filename=response.xml";
+    }
+
+    server {
+        # handle unknown domain names or Host header values
+        listen 80 default_server;
+        return 444;
+    }
+
+    server {
+        # handle unknown domain names or Host header values
+        listen 443 ssl http2 default_server;
+        listen [::]:443 ssl http2 default_server;
+        # are the rest necessary...? maybe move to include file
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_prefer_server_ciphers on;
+        ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+        ssl_ecdh_curve secp384r1;
+        ssl_session_cache shared:SSL:10m;
+        ssl_session_tickets off;
+        ssl_stapling on;
+        ssl_stapling_verify on;
+        ssl_certificate {{ ssl_certificates_path }}/{{ ssl_certificate_name }};
+        ssl_certificate_key {{ ssl_certificates_path }}/{{ ssl_key_name }};
+        ssl_dhparam {{ ssl_certificates_path }}/{{ nginx_dh_param_name }};
+        return 444;
+    }
+
+    server {
+        # port 80 only redirects to https
+        listen 80;
+        server_name {{ server_domain_name }};
+        access_log on;
+        return 301 https://{{ server_domain_name }}$request_uri;
+    }
+
+    upstream elasticsearch {
+        keepalive 15;
+        server {{ searchserver_1_internal_ip | default('127.0.0.1') }}:{{ elasticsearch.port }} weight=3;
+{% if searchserver_2_internal_ip is not undefined %}
+        server {{ searchserver_2_internal_ip }}:{{ elasticsearch.port }};
+{% endif %}
+{% if searchserver_3_internal_ip is not undefined %}
+        server {{ searchserver_3_internal_ip }}:{{ elasticsearch.port }};
+{% endif %}
+    }
+
+    server {
+
+        # https configuration
+
+        listen 443 ssl http2;
+        listen [::]:443 ssl http2;
+        server_name {{ server_domain_name }} 127.0.0.1 localhost;
+
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_prefer_server_ciphers on;
+        ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+        ssl_ecdh_curve secp384r1;
+        ssl_session_cache shared:SSL:10m;
+        ssl_session_tickets off;
+        ssl_stapling on;
+        ssl_stapling_verify on;
+        ssl_certificate {{ ssl_certificates_path }}/{{ ssl_certificate_name }};
+        ssl_certificate_key {{ ssl_certificates_path }}/{{ ssl_key_name }};
+        ssl_dhparam {{ ssl_certificates_path }}/{{ nginx_dh_param_name }};
+
+        resolver 8.8.8.8 8.8.4.4 valid=300s;
+        resolver_timeout 5s;
+
+        client_max_body_size 5G;
+
+{% if deployment_environment_id not in ['production'] %}
+        location =/robots.txt {
+            include shared_headers.conf;
+            include static_file_headers.conf;
+            alias /etc/nginx/robots.txt;
+        }
+{% endif %}
+
+        location /docs/v2 {
+            # general api documentation
+            alias {{ metax_app_base_path }}/docs/v2/build;
+            include shared_headers.conf;
+            include static_file_headers.conf;
+            try_files $uri $uri/ =404;
+        }
+
+        location /docs/v1 {
+            # general api documentation
+            alias {{ metax_app_base_path }}/docs/v1/build;
+            include shared_headers.conf;
+            include static_file_headers.conf;
+            try_files $uri $uri/ =404;
+        }
+
+        location ~ ^/docs$ {
+            # note: for some reason only the above regex seems to work and redirects as intended,
+            # as opposed to how /swagger redirect works below
+            # note: once v2 is taken into use, default should be v2
+            return 301 https://{{ server_domain_name }}/docs/v1;
+        }
+
+        location /apischemas/v2 {
+            # make apischema files available for swagger $ref entries
+            alias {{ metax_app_base_path }}/src/metax_api/api/rest/v2/api_schemas/;
+            include shared_headers.conf;
+            include api_response_headers.conf;
+            try_files $uri $uri/ =404;
+        }
+
+        location /apischemas/v1 {
+            # make apischema files available for swagger $ref entries
+            alias {{ metax_app_base_path }}/src/metax_api/api/rest/base/api_schemas/;
+            include shared_headers.conf;
+            include api_response_headers.conf;
+            try_files $uri $uri/ =404;
+        }
+
+        location /swagger/v2 {
+            include shared_headers.conf;
+            add_header Cache-Control "public" always;
+            add_header Content-Security-Policy "base-uri 'self'; default-src 'self'; style-src 'self' 'unsafe-inline' fonts.googleapis.com cdnjs.cloudflare.com fonts.gstatic.com; font-src 'self' fonts.googleapis.com fonts.gstatic.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' cdnjs.cloudflare.com; object-src 'none';";
+            alias {{ metax_app_base_path }}/swagger/v2/;
+            try_files $uri $uri/ =404;
+        }
+
+        location /swagger/v1 {
+            include shared_headers.conf;
+            add_header Cache-Control "public" always;
+            add_header Content-Security-Policy "base-uri 'self'; default-src 'self'; style-src 'self' 'unsafe-inline' fonts.googleapis.com cdnjs.cloudflare.com fonts.gstatic.com; font-src 'self' fonts.googleapis.com fonts.gstatic.com; script-src 'self' 'unsafe-inline' 'unsafe-eval' cdnjs.cloudflare.com; object-src 'none';";
+            alias {{ metax_app_base_path }}/swagger/v1/;
+            try_files $uri $uri/ =404;
+        }
+
+        location /swagger {
+            # note: once v2 is taken into use, default should be v2
+            return 301 https://{{ server_domain_name }}/swagger/v1;
+        }
+
+        location /es/_search/ {
+            include shared_headers.conf;
+            include elastic_headers.conf;
+            proxy_pass http://elasticsearch/_search/;
+            limit_except GET DELETE {
+                auth_basic 'Credentials required';
+                auth_basic_user_file /etc/nginx/nginx_auth;
+            }
+        }
+
+        location ~ ^/es/(reference_data|organization_data)/_search {
+            # New, correct type of queries can go straight to ES
+            include shared_headers.conf;
+            include elastic_headers.conf;
+            rewrite ^/es/(.*)$ /$1 break;
+            proxy_pass http://elasticsearch;
+            limit_except GET HEAD {
+                auth_basic 'Credentials required';
+                auth_basic_user_file /etc/nginx/nginx_auth;
+            }
+        }
+
+        location ~ ^/es/(_mapping|reference_data|organization_data) {
+            # Sends old types of queries to metax, which will parse
+            # the parameters to be compatible with the new ES version
+            include shared_headers.conf;
+            include api_response_headers.conf;
+            rewrite ^/es/(.*)$ /rpc/elasticsearchs/map_refdata?$1 break;
+            proxy_pass {{ nginx_gunicorn_proxy_pass }};
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+ 
+        location /static/ {
+            include shared_headers.conf;
+            include static_file_headers.conf;
+            alias {{ static_root }}/;
+            try_files $uri $uri/ =404;
+        }
+
+        location /secure/ {
+            include shared_headers.conf;
+            add_header Cache-Control "no-store" always;
+            proxy_pass http://127.0.0.1:{{ httpd_listen_port }}/secure/;
+            proxy_set_header Host {{ server_domain_name }};
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-Port 443;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location ~* ^/(rest|rpc|oai|logout) {
+            # main app
+            include shared_headers.conf;
+            include api_response_headers.conf;
+            proxy_pass {{ nginx_gunicorn_proxy_pass }};
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location / {
+            return 301 https://{{ server_domain_name }}/docs;
+        }
+    }
+}

--- a/ansible/roles/nginx/templates/metax_nginx_test_stable.conf
+++ b/ansible/roles/nginx/templates/metax_nginx_test_stable.conf
@@ -231,6 +231,30 @@ http {
             proxy_pass http://elasticsearch;
         }
 
+        location ~ ^/es/(reference_data|organization_data)/_search {
+            # New, correct type of queries can go straight to ES
+            include shared_headers.conf;
+            include elastic_headers.conf;
+            rewrite ^/es/(.*)$ /$1 break;
+            proxy_pass http://elasticsearch;
+            limit_except GET HEAD {
+                auth_basic 'Credentials required';
+                auth_basic_user_file /etc/nginx/nginx_auth;
+            }
+        }
+
+        location ~ ^/es/(_mapping|reference_data|organization_data) {
+            # Sends old types of queries to metax, which will parse
+            # the parameters to be compatible with the new ES version
+            include shared_headers.conf;
+            include api_response_headers.conf;
+            rewrite ^/es/(.*)$ /rpc/elasticsearchs/map_refdata?$1 break;
+            proxy_pass {{ nginx_gunicorn_proxy_pass }};
+            proxy_set_header X-Forwarded-Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         location /static/ {
             include shared_headers.conf;
             include static_file_headers.conf;


### PR DESCRIPTION
- Required, in order to pass ElasticSearch auth in test/stable while running Travis